### PR TITLE
fix: actually apply and lift AppDynamics action suppression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- fix: the "Create Action Suppression" action now captures the created suppression id, so it is actually deleted again on stop instead of leaving AppDynamics alerting suppressed indefinitely
+- fix: guard the health-rule check against missing target attributes instead of panicking, and avoid a possible nil-dereference when an AppDynamics API request fails before a response is received
+
 ## v1.1.13
 
 - chore(deps): bump github.com/steadybit/extension-kit

--- a/extappdynamics/action_suppression.go
+++ b/extappdynamics/action_suppression.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steadybit/extension-kit/extbuild"
 	"github.com/steadybit/extension-kit/extutil"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -141,16 +142,20 @@ func ActionSuppressionStart(ctx context.Context, state *ActionSuppressionState, 
 	res, err := client.R().
 		SetContext(ctx).
 		SetBody(actionSuppressionRequest).
-		SetResult(&ActionSuppressionResponse{}).
+		SetResult(&actionSuppressionResponse).
 		Post("/controller/alerting/rest/v1/applications/" + state.ApplicationId + "/action-suppressions")
 
+	// resty returns a nil/empty response when err != nil, so res.String() is only safe to
+	// read on the !IsSuccess() path below where err is nil and res is guaranteed non-nil.
 	if err != nil {
-		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to create action suppression in AppDynamics for Application ID %s. Full response: %v", state.ApplicationId, res.String()), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to create action suppression in AppDynamics for Application ID %s.", state.ApplicationId), err))
 	}
 
 	if !res.IsSuccess() {
-		return nil, new(extension_kit.ToError(fmt.Sprintf("AppDynamics API responded with unexpected status code %d while creating action suppression for Application ID %s. Full response: %v", res.StatusCode(), state.ApplicationId, res.String()), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("AppDynamics API responded with unexpected status code %d while creating action suppression for Application ID %s. Full response: %v", res.StatusCode(), state.ApplicationId, res.String()), nil))
 	}
+
+	state.ActionSuppressionId = extutil.Ptr(strconv.Itoa(actionSuppressionResponse.ID))
 
 	return &action_kit_api.StartResult{
 		Messages: &action_kit_api.Messages{
@@ -169,7 +174,7 @@ func ActionSuppressionStop(ctx context.Context, state *ActionSuppressionState, c
 		Delete("/controller/alerting/rest/v1/applications/" + state.ApplicationId + "/action-suppressions/" + *state.ActionSuppressionId)
 
 	if err != nil {
-		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to delete action suppression in AppDynamics for Application ID %s. Full response: %v", state.ApplicationId, res.String()), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to delete action suppression in AppDynamics for Application ID %s.", state.ApplicationId), err))
 	}
 
 	if !res.IsSuccess() {

--- a/extappdynamics/action_suppression_test.go
+++ b/extappdynamics/action_suppression_test.go
@@ -111,6 +111,14 @@ func TestActionSuppressionStartSuccess(t *testing.T) {
 	if receivedReq.DisableAgentReporting != true {
 		t.Errorf("expected DisableAgentReporting true")
 	}
+
+	// The suppression id from the response must be captured so Stop can delete it again.
+	if state.ActionSuppressionId == nil {
+		t.Fatal("expected ActionSuppressionId to be set after start, got nil")
+	}
+	if *state.ActionSuppressionId != "123" {
+		t.Errorf("expected ActionSuppressionId '123', got %q", *state.ActionSuppressionId)
+	}
 }
 
 func TestActionSuppressionStopNoID(t *testing.T) {

--- a/extappdynamics/check_healthrule_violation.go
+++ b/extappdynamics/check_healthrule_violation.go
@@ -217,7 +217,7 @@ func HealthRuleCheckStatus(ctx context.Context, state *HealthRuleCheckState, cli
 	}
 
 	if !res.IsSuccess() {
-		return nil, new(extension_kit.ToError(fmt.Sprintf("AppDynamics API responded with unexpected status code %d while retrieving health rule violations for Application ID %s. Full response: %v", res.StatusCode(), state.HealthRuleApplication, res.String()), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("AppDynamics API responded with unexpected status code %d while retrieving health rule violations for Application ID %s. Full response: %v", res.StatusCode(), state.HealthRuleApplication, res.String()), nil))
 	}
 
 	var checkError *action_kit_api.ActionKitError

--- a/extappdynamics/check_healthrule_violation.go
+++ b/extappdynamics/check_healthrule_violation.go
@@ -171,8 +171,17 @@ func (m *HealthRuleStateCheckAction) Prepare(_ context.Context, state *HealthRul
 		stateCheckMode = fmt.Sprintf("%v", request.Config["stateCheckMode"])
 	}
 
-	state.HealthRuleName = request.Target.Attributes["appdynamics.health-rule.name"][0]
-	state.HealthRuleApplication = request.Target.Attributes["appdynamics.health-rule.application.id"][0]
+	healthRuleName := request.Target.Attributes["appdynamics.health-rule.name"]
+	if len(healthRuleName) == 0 {
+		return nil, new(extension_kit.ToError("Target is missing the 'appdynamics.health-rule.name' attribute.", nil))
+	}
+	healthRuleApplication := request.Target.Attributes["appdynamics.health-rule.application.id"]
+	if len(healthRuleApplication) == 0 {
+		return nil, new(extension_kit.ToError("Target is missing the 'appdynamics.health-rule.application.id' attribute.", nil))
+	}
+
+	state.HealthRuleName = healthRuleName[0]
+	state.HealthRuleApplication = healthRuleApplication[0]
 	state.End = end
 	state.IsViolationExpected = expectedViolation
 	state.StateCheckMode = stateCheckMode
@@ -204,7 +213,7 @@ func HealthRuleCheckStatus(ctx context.Context, state *HealthRuleCheckState, cli
 		Get(uri)
 
 	if err != nil {
-		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to retrieve health rules from AppDynamics for Application ID %s. Full response: %v", state.HealthRuleApplication, res.String()), err))
+		return nil, new(extension_kit.ToError(fmt.Sprintf("Failed to retrieve health rules from AppDynamics for Application ID %s.", state.HealthRuleApplication), err))
 	}
 
 	if !res.IsSuccess() {

--- a/extappdynamics/discovery_applications.go
+++ b/extappdynamics/discovery_applications.go
@@ -130,7 +130,7 @@ func getAllApplications(ctx context.Context, client *resty.Client) []discovery_k
 		Get("/controller/rest/applications?output=JSON")
 
 	if err != nil {
-		log.Err(err).Msgf("Failed to retrieve applications from AppDynamics. Full response: %v", res.String())
+		log.Err(err).Msg("Failed to retrieve applications from AppDynamics.")
 		return result
 	}
 

--- a/extappdynamics/discovery_healthrules.go
+++ b/extappdynamics/discovery_healthrules.go
@@ -145,7 +145,7 @@ func getAllHealthRules(ctx context.Context, client *resty.Client) []discovery_ki
 		Get("/controller/rest/applications?output=JSON")
 
 	if err != nil {
-		log.Err(err).Msgf("Failed to retrieve applications from AppDynamics. Full response: %v", res.String())
+		log.Err(err).Msg("Failed to retrieve applications from AppDynamics.")
 		return result
 	}
 
@@ -169,7 +169,7 @@ func getAllHealthRules(ctx context.Context, client *resty.Client) []discovery_ki
 			Get("/controller/alerting/rest/v1/applications/" + strconv.Itoa(app.ID) + "/health-rules?output=JSON")
 
 		if err != nil {
-			log.Err(err).Msgf("Failed to retrieve health rules from AppDynamics with application %d. Full response: %v", app.ID, res.String())
+			log.Err(err).Msgf("Failed to retrieve health rules from AppDynamics with application %d.", app.ID)
 			return result
 		}
 


### PR DESCRIPTION
## Problem (HIGH)

The **Create Action Suppression** action never lifted the suppression it created, so AppDynamics alerting/monitoring stayed suppressed **indefinitely** after the experiment ended.

Root cause in `ActionSuppressionStart` (`extappdynamics/action_suppression.go`):
- `SetResult(&ActionSuppressionResponse{})` parsed the API response into a **throwaway struct**, leaving the local `actionSuppressionResponse` zero-valued.
- `state.ActionSuppressionId` was **never assigned**.
- So `ActionSuppressionStop` always hit `if state.ActionSuppressionId == nil { return nil, nil }` and returned immediately — the `DELETE` was never sent.
- The success message also always printed `Action Suppression ID 0`.

### Fix
Parse the response into the variable that is actually read, and store the returned id so `Stop` deletes the suppression:
```go
SetResult(&actionSuppressionResponse)
...
state.ActionSuppressionId = extutil.Ptr(strconv.Itoa(actionSuppressionResponse.ID))
```
The existing `TestActionSuppressionStartSuccess` returned `{"id":123}` but never asserted it was captured — added that assertion as a regression guard.

## Also fixed (MAJOR)

- **Attribute-index panic** in `check_healthrule_violation.go` `Prepare`: `Attributes["appdynamics.health-rule.name"][0]` / `["...application.id"][0]` were indexed without a length check (only `.id` was guarded). A target missing either attribute panicked the handler. Now length-guarded with clear errors.
- **nil-dereference on transport errors**: several `err != nil` branches called `res.String()`, but resty returns a nil/empty response when a request fails before a response is received (e.g. a before-request failure), so `res.String()` could panic. Removed `res.String()` from the error paths (the resty error is still surfaced via `ToError`); kept it on the `!IsSuccess()` paths where `res` is non-nil and the body is the only diagnostic. Added a comment documenting the invariant.

## Testing
- `go build ./...`, `gofmt`, `go vet`, `go test ./extappdynamics/` all pass.
- Ran `/simplify` (4-agent reuse/simplification/efficiency/altitude pass): diff confirmed at the right altitude; applied the one suggested cleanup (the invariant comment) and skipped an optional attribute-guard helper as gold-plating.