### PR TITLE
feat(health rule check): add fail early option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Add a "Fail early" option to the health rule check. When enabled (the default, matching the previous behavior), the check fails as soon as a deviating state is observed. When disabled, the check keeps collecting events for the whole duration and only fails at the end of the step (with a past-tense message, since the state may have recovered by then).
 - fix: the "Create Action Suppression" action now captures the created suppression id, so it is actually deleted again on stop instead of leaving AppDynamics alerting suppressed indefinitely
 - fix: guard the health-rule check against missing target attributes instead of panicking, and avoid a possible nil-dereference when an AppDynamics API request fails before a response is received
 

--- a/extappdynamics/check_healthrule_violation.go
+++ b/extappdynamics/check_healthrule_violation.go
@@ -39,6 +39,11 @@ type HealthRuleCheckState struct {
 	IsViolationExpected   bool
 	StateCheckMode        string
 	StateCheckSuccess     bool
+	FailEarly             bool
+	// DeviationSeen and DeviationTitle are used in 'fail at end' mode (FailEarly = false) to remember
+	// that a deviating state was observed during the step so the failure can be reported once the step ends.
+	DeviationSeen  bool
+	DeviationTitle string
 }
 
 func NewHealthRuleStateCheckAction() action_kit_sdk.Action[HealthRuleCheckState] {
@@ -119,6 +124,16 @@ func (m *HealthRuleStateCheckAction) Describe() action_kit_api.ActionDescription
 				Required: new(true),
 				Order:    new(3),
 			},
+			{
+				Name:         "failEarly",
+				Label:        "Fail early",
+				Description:  new("If enabled, the check fails as soon as a deviating state is observed. If disabled, the check keeps collecting events for the whole duration and only fails at the end of the step. Only affects the 'All the time' mode; 'At least once' can only be evaluated at the end of the step."),
+				Type:         action_kit_api.Boolean,
+				DefaultValue: new("true"),
+				Advanced:     new(true),
+				Required:     new(false),
+				Order:        new(4),
+			},
 		},
 		Widgets: new([]action_kit_api.Widget{
 			action_kit_api.StateOverTimeWidget{
@@ -180,6 +195,12 @@ func (m *HealthRuleStateCheckAction) Prepare(_ context.Context, state *HealthRul
 		return nil, new(extension_kit.ToError("Target is missing the 'appdynamics.health-rule.application.id' attribute.", nil))
 	}
 
+	// Default to failing early to preserve the previous behavior for experiments that don't set this parameter.
+	state.FailEarly = true
+	if request.Config["failEarly"] != nil {
+		state.FailEarly = extutil.ToBool(request.Config["failEarly"])
+	}
+
 	state.HealthRuleName = healthRuleName[0]
 	state.HealthRuleApplication = healthRuleApplication[0]
 	state.End = end
@@ -225,11 +246,28 @@ func HealthRuleCheckStatus(ctx context.Context, state *HealthRuleCheckState, cli
 
 	if state.StateCheckMode == StateCheckModeAllTheTime {
 		if !state.IsViolationExpected == healthRuleHasViolations {
-			checkError = new(action_kit_api.ActionKitError{
-				Title: fmt.Sprintf("HealthRule '%s' has violations '%t' whereas 'Violations Expected: %t'.",
+			if state.FailEarly {
+				// Fail as soon as a deviating state is observed (present tense - it is deviating now).
+				checkError = new(action_kit_api.ActionKitError{
+					Title: fmt.Sprintf("HealthRule '%s' has violations '%t' whereas 'Violations Expected: %t'.",
+						state.HealthRuleName,
+						healthRuleHasViolations,
+						state.IsViolationExpected),
+					Status: extutil.Ptr(action_kit_api.Failed),
+				})
+			} else {
+				// Keep collecting events and remember the deviation to report it at the end of the
+				// step (past tense - the state may have recovered by the time this is reported).
+				state.DeviationSeen = true
+				state.DeviationTitle = fmt.Sprintf("HealthRule '%s' had violations '%t' whereas 'Violations Expected: %t'.",
 					state.HealthRuleName,
 					healthRuleHasViolations,
-					state.IsViolationExpected),
+					state.IsViolationExpected)
+			}
+		}
+		if !state.FailEarly && completed && state.DeviationSeen {
+			checkError = new(action_kit_api.ActionKitError{
+				Title:  state.DeviationTitle,
 				Status: extutil.Ptr(action_kit_api.Failed),
 			})
 		}

--- a/extappdynamics/check_healthrule_violation_test.go
+++ b/extappdynamics/check_healthrule_violation_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +65,7 @@ func TestHealthRuleCheckStatus_NoViolations_AllTheTime(t *testing.T) {
 // TestHealthRuleCheckStatus_ViolationsUnexpected_AllTheTime tests AllTheTime mode when a violation occurs but none are expected.
 func TestHealthRuleCheckStatus_ViolationsUnexpected_AllTheTime(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusOK)
 		w.Write([]byte(`[{"name":"foo"}]`))
 	}))
@@ -76,6 +78,7 @@ func TestHealthRuleCheckStatus_ViolationsUnexpected_AllTheTime(t *testing.T) {
 		End:                   time.Now().Add(-time.Second),
 		IsViolationExpected:   false,
 		StateCheckMode:        StateCheckModeAllTheTime,
+		FailEarly:             true,
 	}
 
 	res, err := HealthRuleCheckStatus(context.Background(), &state, client)
@@ -84,6 +87,55 @@ func TestHealthRuleCheckStatus_ViolationsUnexpected_AllTheTime(t *testing.T) {
 	}
 	if !res.Completed {
 		t.Error("expected Completed to be true")
+	}
+	if res.Error == nil {
+		t.Error("expected an error because an unexpected violation occurred")
+	}
+}
+
+// TestHealthRuleCheckStatus_AllTheTime_FailAtEnd verifies that with fail early disabled the deviation is
+// reported only once the step ends, using the past-tense message.
+func TestHealthRuleCheckStatus_AllTheTime_FailAtEnd(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`[{"name":"foo"}]`))
+	}))
+	defer ts.Close()
+
+	client := resty.New().SetHostURL(ts.URL)
+
+	// Not yet completed: a deviation is observed but must not fail early.
+	state := HealthRuleCheckState{
+		HealthRuleName:        "foo",
+		HealthRuleApplication: "app",
+		End:                   time.Now().Add(time.Minute),
+		IsViolationExpected:   false,
+		StateCheckMode:        StateCheckModeAllTheTime,
+		FailEarly:             false,
+	}
+	res, err := HealthRuleCheckStatus(context.Background(), &state, client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error != nil {
+		t.Error("expected no error before the step ends (fail early disabled)")
+	}
+	if !state.DeviationSeen {
+		t.Error("expected the deviation to be remembered")
+	}
+
+	// Completed: the remembered deviation is reported with the past-tense message.
+	state.End = time.Now().Add(-time.Second)
+	res, err = HealthRuleCheckStatus(context.Background(), &state, client)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Error == nil {
+		t.Fatal("expected an error at the end of the step")
+	}
+	if !strings.Contains(res.Error.Title, "had violations") {
+		t.Errorf("expected past-tense message, got %q", res.Error.Title)
 	}
 }
 


### PR DESCRIPTION
## Problem

The ending time of our checks isn't consistently applied, which makes experiments hard to time. A check can fail early (on the first deviating event) or only at the end of the step, with no way to choose. This adds a per-check option, following the reference implementation in `extension-datadog` (and matching dynatrace/grafana/kafka).

## Change

Adds a **`failEarly` boolean** to the AppDynamics health rule check:

- **Enabled (default)** — the check fails as soon as a deviating state is observed (today's `All the time` behavior).
- **Disabled** — the check keeps collecting events for the whole step duration and only fails at the end, using a **past-tense** message ("had violations") since the state may have recovered by then.

Details:
- Parameter lives in the **Advanced** section, is **optional**, and defaults to `true` both in its description and in `Prepare` (when the key is absent), so **existing experiments are non-breaking**.
- Fail-at-end is implemented by remembering the deviation in state (`DeviationSeen`/`DeviationTitle`).
- Only affects `All the time` mode; `At least once` can only be evaluated at the end of the step.

## Note

`healthRuleHasViolations` is always a determinate bool, so the "unknown/no-data silently passes" bug fixed in datadog#216 does **not** apply here.

## Tests

- Strengthened `ViolationsUnexpected_AllTheTime` to assert the fail-early error, and added `AllTheTime_FailAtEnd` (deferred past-tense failure). Both set `Content-Type: application/json` so the violation body is actually parsed.
- All `extappdynamics` tests pass, `go vet` clean.