### PR TITLE
chore: normalize dependabot-auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -5,6 +5,10 @@ permissions:
   contents: write
   pull-requests: write
 
+# WARNING - Make sure the repo:
+# - has setup up branch protection rules (required status checks) - otherwise all PR will be merged without waiting for build results
+# - allows auto-merge (settings -> general -> Pull Requests -> Allow Auto-Merge)
+
 jobs:
   dependabot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Sync the `dependabot-auto-merge.yml` workflow to the standard version used across the other extensions and kits. No behavioral change — comment/whitespace only (this repo's copy had drifted). Branch protection and auto-merge are already configured here.