### PR TITLE
fix: remove 'monitoring' category from suppression action for consistent grouping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- fix: remove the "monitoring" category from the "Create Action Suppression" action so both actions are grouped consistently in the experiment editor
+
 ## v1.1.16
 
 - chore(deps): update dependencies

--- a/extappdynamics/action_suppression.go
+++ b/extappdynamics/action_suppression.go
@@ -64,7 +64,6 @@ func (m *ActionSuppressionAction) Describe() action_kit_api.ActionDescription {
 				},
 			}),
 		}),
-		Category:    new("monitoring"),
 		Kind:        action_kit_api.Other,
 		TimeControl: action_kit_api.TimeControlExternal,
 		Parameters: []action_kit_api.ActionParameter{


### PR DESCRIPTION
## What

Removes the `monitoring` category from the **Create Action Suppression** action description.

## Why

In the experiment editor the two AppDynamics actions appeared on separate lines: `Create Action Suppression` declared `Category: "monitoring"` while `Health Rule Check` had no category. Removing the category (as suggested in the ticket) makes both actions uncategorized and consistent with other extensions.

The `monitoring` category on the discovery target definitions is a separate concept and is intentionally left unchanged.

Fixes [card 22433](https://steadybitgmbh.kanbanize.com/ctrl_board/2/cards/22433/details/).

## Testing

- `go build ./...` and `go test ./extappdynamics/` pass (21 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)