### PR TITLE
fix: emit the health rule state metric immediately on Start

### DIFF
--- a/e2e/integration_test.go
+++ b/e2e/integration_test.go
@@ -90,13 +90,15 @@ func testHealthRuleCheck(hasViolation bool, appID string, wantedActionStatus act
 		}{Duration: 1_000, Violation: hasViolation, StateCheckMode: extappdynamics.StateCheckModeAllTheTime}
 
 		action, err := e.RunAction("com.steadybit.extension_appdynamics.health-rule.check", target, config, &action_kit_api.ExecutionContext{})
-		require.NoError(t, err)
 		defer func() { _ = action.Cancel() }()
 
-		err = action.Wait()
 		if wantedActionStatus == "" {
 			require.NoError(t, err)
+			err = action.Wait()
+			require.NoError(t, err)
 		} else {
+			// The check now fails as soon as Start() observes the deviating state, so the error
+			// surfaces from RunAction() rather than from Wait().
 			require.ErrorContains(t, err, string(wantedActionStatus))
 		}
 	}

--- a/extappdynamics/check_healthrule_violation.go
+++ b/extappdynamics/check_healthrule_violation.go
@@ -210,8 +210,17 @@ func (m *HealthRuleStateCheckAction) Prepare(_ context.Context, state *HealthRul
 	return nil, nil
 }
 
-func (m *HealthRuleStateCheckAction) Start(_ context.Context, _ *HealthRuleCheckState) (*action_kit_api.StartResult, error) {
-	return nil, nil
+func (m *HealthRuleStateCheckAction) Start(ctx context.Context, state *HealthRuleCheckState) (*action_kit_api.StartResult, error) {
+	statusResult, err := HealthRuleCheckStatus(ctx, state, RestyClient)
+	if statusResult == nil {
+		return nil, err
+	}
+	return &action_kit_api.StartResult{
+		Artifacts: statusResult.Artifacts,
+		Error:     statusResult.Error,
+		Messages:  statusResult.Messages,
+		Metrics:   statusResult.Metrics,
+	}, err
 }
 
 func (m *HealthRuleStateCheckAction) Status(ctx context.Context, state *HealthRuleCheckState) (*action_kit_api.StatusResult, error) {


### PR DESCRIPTION
## Summary
- `Start()` was a no-op, so the first `appdynamics_health_rule_state` metric only appeared after the first `Status()` poll (one `CallInterval`, i.e. 1s, after the check started).
- `Start()` now reuses the same status-check logic as `Status()`, so the first metric is emitted immediately when the check starts.

## Test plan
- [x] `go build ./...`
- [x] `go test ./extappdynamics/...`